### PR TITLE
remove kernel_name

### DIFF
--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -546,6 +546,7 @@ class BaseProcessProxyABC(metaclass=abc.ABCMeta):
 
         # Remove kernel_headers
         kwargs.pop("kernel_headers", None)
+        kwargs.pop("kernel_name", None)
         return launch_kernel(cmd, **kwargs)
 
     def cleanup(self) -> None:  # noqa


### PR DESCRIPTION
kernel_name comes as part of scala kernel restart payload. It is not support as a parameter to launch_ipykernel and needs to be removed just as kernel_headers

# Jira Ticket

[BGD-6043](https://spotinst.atlassian.net/browse/BGD-6043)

# Demo

Run a scala notebooks, when ready, restart it. The notebook service no longer shows the 'kernel_name' error when launching restarted kernel

# Checklist:
- [x] I have filled relevant self assessment ([NodeJS](https://docs.google.com/forms/d/e/1FAIpQLSfl14u9AOBAmxVJ272tvO7XNuXE-EMvWaGcaRZalu1UAKB7RA/viewform), [Frontend](https://docs.google.com/forms/d/e/1FAIpQLSdiBPNKH81w_EkavihVL8Uwb0j7tP8PwJmLFYm2nCOQxz-1qw/viewform), [Backend](https://docs.google.com/forms/d/e/1FAIpQLSed_PsTJ5-XIWkFL6BSDE2AQRBVPmwc3PAmHZkUn-erzVI37Q/viewform?usp=sf_link))
- [x] I have run ESlint on my changes and fixed all warnings and errors (**NodeJS & Frontend Services**)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have validated all the requirements in the Jira task were answered
- [x] I have all neccessary approvals for the design/mini design of this task
- [x] I have approved the API changes and granular permission patterns (documentation subtask) (**For public services only**) 


[BGD-6043]: https://spotinst.atlassian.net/browse/BGD-6043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ